### PR TITLE
Change capital package names

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,9 +3,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,6 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -13,6 +16,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="testRunner" value="PLATFORM" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,43 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="4">
+        <list size="12">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="4" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="android.annotation.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
+          <item index="11" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="4">
+        <list size="11">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+          <item index="4" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
+          <item index="5" class="java.lang.String" itemvalue="android.annotation.NonNull" />
+          <item index="6" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
         </list>
       </value>
     </option>
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -5,6 +5,8 @@
       <module fileurl="file://$PROJECT_DIR$/example/example.iml" filepath="$PROJECT_DIR$/example/example.iml" />
       <module fileurl="file://$PROJECT_DIR$/supernova.iml" filepath="$PROJECT_DIR$/supernova.iml" />
       <module fileurl="file://$PROJECT_DIR$/supernova-emoji-library/supernova-emoji-library.iml" filepath="$PROJECT_DIR$/supernova-emoji-library/supernova-emoji-library.iml" />
+      <module fileurl="file://$PROJECT_DIR$/example/supernova-example.iml" filepath="$PROJECT_DIR$/example/supernova-example.iml" />
+      <module fileurl="file://$PROJECT_DIR$/supernova-emoji-library/supernova-supernova-emoji-library.iml" filepath="$PROJECT_DIR$/supernova-emoji-library/supernova-supernova-emoji-library.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/SuperNova-Emoji.iml" filepath="$PROJECT_DIR$/SuperNova-Emoji.iml" />
       <module fileurl="file://$PROJECT_DIR$/example/example.iml" filepath="$PROJECT_DIR$/example/example.iml" />
+      <module fileurl="file://$PROJECT_DIR$/supernova.iml" filepath="$PROJECT_DIR$/supernova.iml" />
       <module fileurl="file://$PROJECT_DIR$/supernova-emoji-library/supernova-emoji-library.iml" filepath="$PROJECT_DIR$/supernova-emoji-library/supernova-emoji-library.iml" />
     </modules>
   </component>

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 ![AppVeyor branch](https://img.shields.io/appveyor/ci/gruntjs/grunt/master.svg)
 [![](https://jitpack.io/v/hani-momanii/SuperNova-Emoji.svg)](https://jitpack.io/#hani-momanii/SuperNova-Emoji)
 
-## [Release Notes](https://github.com/hani-momanii/SuperNova-Emoji/releases)
+## [Release Notes](https://github.com/chulunus/SuperNova-Emoji/releases)
  
 
 ## SuperNova-Emoji
 
-[SuperNova-Emoji](https://github.com/hani-momanii/SuperNova-Emoji) is a library to implement and render emojis.
+[SuperNova-Emoji](https://github.com/chulunus/SuperNova-Emoji) is a library to implement and render emojis.
 Minimum SDK Level: 9 (2.3)
 
 
-![image](https://github.com/hani-momanii/SuperNova-Emoji/blob/master/vid.gif)
+![image](https://github.com/chulunus/SuperNova-Emoji/blob/master/vid.gif)
 
 ## Contact
 
@@ -38,7 +38,7 @@ EmojIconActions  emojIcon=new EmojIconActions(this,rootView,emojiconEditText,emo
 emojIcon.ShowEmojIcon();
 ```
 
-![image](https://github.com/hani-momanii/SuperNova-Emoji/blob/master/ios.png)
+![image](https://github.com/chulunus/SuperNova-Emoji/blob/master/ios.png)
 
 
 To use custom color :
@@ -47,7 +47,7 @@ EmojIconActions(Context ctx,View rootView,EmojiconEditText emojiconEditText,Imag
 EmojIconActions  emojIcon=new EmojIconActions(this,rootView,emojiconEditText,emojiButton,"#495C66","#DCE1E2","#E6EBEF");
 emojIcon.ShowEmojIcon();
 ```
-![image](https://github.com/hani-momanii/SuperNova-Emoji/blob/master/color.png)
+![image](https://github.com/chulunus/SuperNova-Emoji/blob/master/color.png)
 
 
 
@@ -70,7 +70,7 @@ To use the device default emoji
 emojIcon.setUseSystemEmoji(true);
 emojiconEditText.setUseSystemEmoji(true);
 ```
-![image](https://github.com/hani-momanii/SuperNova-Emoji/blob/master/def.png)
+![image](https://github.com/chulunus/SuperNova-Emoji/blob/master/def.png)
 
 
 
@@ -109,7 +109,7 @@ Via Gradle:
 repositories {
     maven { url 'https://jitpack.io' }
 }
-compile 'com.github.hani-momanii:SuperNova-Emoji:1.2'
+compile 'com.github.chulunus:SuperNova-Emoji:1.2'
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Via Gradle:
 repositories {
     maven { url 'https://jitpack.io' }
 }
-compile 'com.github.hani-momanii:SuperNova-Emoji:1.1'
+compile 'com.github.hani-momanii:SuperNova-Emoji:1.2'
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ emojiconEditText.setUseSystemEmoji(true);
 ## XML Usage
 
 ```
-<hani.momanii.supernova_emoji_library.Helper.EmojiconEditText
+<hani.momanii.supernova_emoji_library.helper.EmojiconEditText
         android:id="@+id/emojicon_edit_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         emojicon:emojiconSize="28sp" />
         
         
-<hani.momanii.supernova_emoji_library.Helper.EmojiconTextView
+<hani.momanii.supernova_emoji_library.helper.EmojiconTextView
         android:id="@+id/emojicon_text_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" 

--- a/example/src/main/java/momanii/hani/supernova_emoji/MainActivity.java
+++ b/example/src/main/java/momanii/hani/supernova_emoji/MainActivity.java
@@ -8,9 +8,9 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.ImageView;
 
-import hani.momanii.supernova_emoji_library.Actions.EmojIconActions;
-import hani.momanii.supernova_emoji_library.Helper.EmojiconEditText;
-import hani.momanii.supernova_emoji_library.Helper.EmojiconTextView;
+import hani.momanii.supernova_emoji_library.actions.EmojIconActions;
+import hani.momanii.supernova_emoji_library.helper.EmojiconEditText;
+import hani.momanii.supernova_emoji_library.helper.EmojiconTextView;
 
 public class MainActivity extends AppCompatActivity {
 

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -29,7 +29,7 @@
         android:src="@android:drawable/ic_menu_send"
         />
 
-    <hani.momanii.supernova_emoji_library.Helper.EmojiconEditText
+    <hani.momanii.supernova_emoji_library.helper.EmojiconEditText
         android:id="@+id/emojicon_edit_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -41,7 +41,7 @@
         emojicon:emojiconSize="28sp"/>
 
 
-    <hani.momanii.supernova_emoji_library.Helper.EmojiconEditText
+    <hani.momanii.supernova_emoji_library.helper.EmojiconEditText
         android:id="@+id/emojicon_edit_text2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -60,7 +60,7 @@
         android:checked="false"
         android:text="Use System Default?"/>
 
-    <hani.momanii.supernova_emoji_library.Helper.EmojiconTextView
+    <hani.momanii.supernova_emoji_library.helper.EmojiconTextView
         android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Actions/EmojIconActions.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Actions/EmojIconActions.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package hani.momanii.supernova_emoji_library.Actions;
+package hani.momanii.supernova_emoji_library.actions;
 
 import android.content.Context;
 import android.view.KeyEvent;
@@ -26,9 +26,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import hani.momanii.supernova_emoji_library.Helper.EmojiconEditText;
-import hani.momanii.supernova_emoji_library.Helper.EmojiconGridView;
-import hani.momanii.supernova_emoji_library.Helper.EmojiconsPopup;
+import hani.momanii.supernova_emoji_library.helper.EmojiconEditText;
+import hani.momanii.supernova_emoji_library.helper.EmojiconGridView;
+import hani.momanii.supernova_emoji_library.helper.EmojiconsPopup;
 import hani.momanii.supernova_emoji_library.R;
 import hani.momanii.supernova_emoji_library.emoji.Emojicon;
 

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiAdapter.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiAdapter.java
@@ -16,7 +16,7 @@
 
 
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.content.Context;
 import android.view.View;

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconEditText.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconEditText.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.content.Context;
 import android.content.res.TypedArray;

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconGridView.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconGridView.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.app.Activity;
 import android.content.Context;

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconHandler.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconHandler.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.content.Context;
 import android.text.Spannable;

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconMultiAutoCompleteTextView.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconMultiAutoCompleteTextView.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.content.Context;
 import android.content.res.TypedArray;

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconRecents.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconRecents.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.content.Context;
 

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconRecentsGridView.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconRecentsGridView.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.content.Context;
 import android.widget.GridView;

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconRecentsManager.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconRecentsManager.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 import android.content.Context;
 import android.content.SharedPreferences;
 import java.util.ArrayList;

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconSpan.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconSpan.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.content.Context;
 import android.graphics.Canvas;

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconTextView.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconTextView.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.content.Context;
 import android.content.res.TypedArray;

--- a/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconsPopup.java
+++ b/supernova-emoji-library/src/main/java/hani/momanii/supernova_emoji_library/Helper/EmojiconsPopup.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hani.momanii.supernova_emoji_library.Helper;
+package hani.momanii.supernova_emoji_library.helper;
 
 import android.app.Activity;
 import android.content.Context;

--- a/supernova-emoji-library/src/main/res/layout/emojicon_item.xml
+++ b/supernova-emoji-library/src/main/res/layout/emojicon_item.xml
@@ -19,7 +19,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
-    <hani.momanii.supernova_emoji_library.Helper.EmojiconTextView
+    <hani.momanii.supernova_emoji_library.helper.EmojiconTextView
         android:layout_gravity="center"
         android:id="@+id/emojicon_icon"
         android:layout_width="36dip"


### PR DESCRIPTION
There were some java package names that began with a capital letter.
This didn't play well for some auto - generated code which assumes all package names are lowercase.